### PR TITLE
Change supertype of AbstractPosit to AbstractFloat

### DIFF
--- a/src/typedef.jl
+++ b/src/typedef.jl
@@ -1,4 +1,4 @@
-abstract type AbstractPosit <: Real end
+abstract type AbstractPosit <: AbstractFloat end
 
 # Posit8 with 0 exponent bits, Posit16 with 1 and Posit32 with 2
 primitive type Posit8 <: AbstractPosit 8 end


### PR DESCRIPTION
I think it's more natural to make `AbstractPosit <: AbstractFloat` rather than `Real`.